### PR TITLE
change loss.numpy()[0] to float(loss) to adapt 0D

### DIFF
--- a/competitions/mrc_utils.py
+++ b/competitions/mrc_utils.py
@@ -780,11 +780,11 @@ def IG_predict_fn(inputs, label, left=None, right=None, steps=None, paddle_model
     probas_end.stop_gradient = True
 
     probas =[]
-    for idx in range(len(probas_start)):#(preds_start.numpy(), preds_end.numpy())
+    for idx in range(len(probas_start)):    #(preds_start.numpy(), preds_end.numpy())
         probas.append([probas_start[idx].numpy(), probas_end[idx].numpy()])
     preds =[]
-    for idx in range(len(preds_start)):#(preds_start.numpy(), preds_end.numpy())
-        preds.append([preds_start[idx].numpy()[0],preds_end[idx].numpy()[0]])
+    for idx in range(len(preds_start)):     #(preds_start.numpy(), preds_end.numpy())
+        preds.append([int(preds_start[idx]), int(preds_end[idx])])
     preds = np.array(preds)
     return gradients, preds, target_feature_map[0].numpy(), probas
 


### PR DESCRIPTION
loss正确的语义为0D Tensor，其shape为[]，当前使用了shape为[1]替代，也就是向量Tensor：

在进行升级为0D后，`loss.numpy()[0]` 的写法不再使用，将其改变为 `float(loss)` 的写法，在升级前(shape为[1])、升级后(shape为[])下都同样适用，兼容改法。