### PR TITLE
Add support for paddle 2.5.0+

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,21 +2,21 @@
 # https://setuptools.readthedocs.io/en/latest/setuptools.html#configuring-setup-using-setup-cfg-files
 [metadata]
 # Project name, the project name will be used while publishing and installing
-name = trustai
+name = trustai-new
 # Author's name and email address
-author = Baidu NLP
-author_email = nlp-parser@baidu.com
+author = Baidu NLP / HalfCooler6182(NeptuneZhao)
+author_email = nlp-parser@baidu.com / qq1836143240@outlook.com
 # Project version, versions only above than 1.0 will assumed as a released version.
 # When modifying project version to above than 1.0, here's the rules should be followed.
 # http://wiki.baidu.com/pages/viewpage.action?pageId=469686381
-version = 0.1.12
+version = 0.2.0
 # A brief introduction about the project, ANY NON-ENGLISH CHARACTER IS NOT SUPPORTED!
-description = baidu TrustAI
+description = New TrusiAI supported for paddle >= 2.5 from baidu TrustAI
 # A longer version of introduction abouth the project, you can also include readme, change log, etc. .md or rst file is recommended.
 long_description = file: README.md
 long_description_content_type = text/markdown
 # Main page of the project, usually the project's icode page, you can set to its wiki or other documents url instead.
-home_page = https://github.com/PaddlePaddle/TrustAI
+home_page = https://github.com/NeptuneZhao/TrusiAI-New
 # License, you can ignore this if the project is not going to open source to the public.
 license = Apache License 2.0
 # Project type, you can ignore this if the project is not going to open source to the public.
@@ -24,9 +24,7 @@ license = Apache License 2.0
 # https://pypi.org/pypi?%3Aaction=list_classifiers
 classifier =
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
-    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.12
     License :: OSI Approved :: Apache Software License
     Operating System :: OS Independent
 # keywords, used for indexing, easier to search for other users if they are interested of your project.

--- a/trustai/demo/demo.py
+++ b/trustai/demo/demo.py
@@ -18,9 +18,6 @@ import logging.handlers
 import os
 import sys
 import re
-import requests
-import shutil
-import tarfile
 import warnings
 import functools
 

--- a/trustai/evaluation/evaluator.py
+++ b/trustai/evaluation/evaluator.py
@@ -13,14 +13,6 @@
 # limitations under the License.
 """This script includes code to calculate MAP score"""
 
-import json
-import re
-import os
-import math
-import numpy as np
-import argparse
-
-
 class Evaluator():
     """Evaluate prediction data.
     """

--- a/trustai/interpretation/example_level/common/data_class.py
+++ b/trustai/interpretation/example_level/common/data_class.py
@@ -3,10 +3,7 @@ data class
 """
 
 from dataclasses import dataclass
-from typing import Any
 from typing import List
-from typing import Dict
-from typing import Tuple
 
 
 @dataclass

--- a/trustai/interpretation/example_level/common/utils.py
+++ b/trustai/interpretation/example_level/common/utils.py
@@ -14,7 +14,6 @@
 """Some useful functions."""
 import paddle
 import paddle.nn.functional as F
-import numpy as np
 from .data_class import ExampleResult
 
 

--- a/trustai/interpretation/example_level/method/feature_similarity.py
+++ b/trustai/interpretation/example_level/method/feature_similarity.py
@@ -4,12 +4,8 @@ feature-based similarity method.
 cosine, cot and euc.
 """
 import os
-import sys
-import functools
-import warnings
 
 import paddle
-import paddle.nn.functional as F
 from tqdm import tqdm
 
 from ..common.utils import get_sublayer, dot_similarity, cos_similarity, euc_similarity, get_top_and_bottom_n_examples

--- a/trustai/interpretation/example_level/method/gradient_similarity.py
+++ b/trustai/interpretation/example_level/method/gradient_similarity.py
@@ -4,11 +4,7 @@ gradient-based similarity method.
 cosine and dot.
 """
 import os
-import functools
-import warnings
-
 import paddle
-import paddle.nn.functional as F
 from tqdm import tqdm
 
 from ..common.utils import get_sublayer, dot_similarity, cos_similarity, euc_similarity, get_top_and_bottom_n_examples

--- a/trustai/interpretation/example_level/method/representer_point.py
+++ b/trustai/interpretation/example_level/method/representer_point.py
@@ -14,14 +14,12 @@
 """representer point"""
 
 import logging
-import functools
 
 import paddle
 import paddle.nn as nn
 import paddle.nn.functional as F
 from tqdm import tqdm
 
-from ...base_interpret import Interpreter
 from .example_base_interpreter import ExampleBaseInterpreter
 from ..common.utils import get_sublayer, get_top_and_bottom_n_examples
 

--- a/trustai/interpretation/token_level/common/predict_functions.py
+++ b/trustai/interpretation/token_level/common/predict_functions.py
@@ -15,8 +15,6 @@
 
 import numpy as np
 import paddle
-from paddle import tensor
-from paddle.fluid import layers
 
 
 def attention_predict_fn_on_paddlenlp(inputs,
@@ -57,11 +55,11 @@ def attention_predict_fn_on_paddlenlp(inputs,
     num_heads = paddle_model.ernie.config['num_attention_heads']
     hidden_size = paddle_model.ernie.config['hidden_size']
     head_dim = hidden_size // num_heads
-    q = tensor.reshape(x=query_feature[0], shape=[0, 0, num_heads, head_dim])
-    q = tensor.transpose(x=q, perm=[0, 2, 1, 3])
-    k = tensor.reshape(x=key_feature[0], shape=[0, 0, num_heads, head_dim])
-    k = tensor.transpose(x=k, perm=[0, 2, 1, 3])
-    attention = layers.matmul(x=q, y=k, transpose_y=True, alpha=head_dim**-0.5)
+    q = paddle.tensor.reshape(x=query_feature[0], shape=[0, 0, num_heads, head_dim])
+    q = paddle.tensor.transpose(x=q, perm=[0, 2, 1, 3])
+    k = paddle.tensor.reshape(x=key_feature[0], shape=[0, 0, num_heads, head_dim])
+    k = paddle.tensor.transpose(x=k, perm=[0, 2, 1, 3])
+    attention = paddle.matmul(x=q, y=k, transpose_y=True)
 
     attention = attention.sum(1)[:, 0]
 
@@ -128,11 +126,11 @@ def ig_predict_fn_on_paddlenlp_pretrain(inputs,
     probas = paddle.nn.functional.softmax(logits, axis=2)  # get probabilities.
     preds = paddle.argmax(probas, axis=2)  # get predictions.
     mask_num = masked_positions.sum(axis=1).tolist()
-    logits = paddle.gather_nd(logits, layers.where(masked_positions))
+    logits = paddle.gather_nd(logits, paddle.fluid.layers.where(masked_positions))
     logits = logits.split(num_or_sections=mask_num)
-    probas = paddle.gather_nd(probas, layers.where(masked_positions))
+    probas = paddle.gather_nd(probas, paddle.fluid.layers.where(masked_positions))
     probas = probas.split(num_or_sections=mask_num)
-    preds = paddle.gather_nd(preds, layers.where(masked_positions))
+    preds = paddle.gather_nd(preds, paddle.fluid.layers.where(masked_positions))
     preds = preds.split(num_or_sections=mask_num)
 
     if label is None:
@@ -199,11 +197,11 @@ def attention_predict_fn_on_paddlenlp_pretrain(inputs,
     num_heads = paddle_model.ernie.config['num_attention_heads']
     hidden_size = paddle_model.ernie.config['hidden_size']
     head_dim = hidden_size // num_heads
-    q = tensor.reshape(x=query_feature[0], shape=[0, 0, num_heads, head_dim])
-    q = tensor.transpose(x=q, perm=[0, 2, 1, 3])
-    k = tensor.reshape(x=key_feature[0], shape=[0, 0, num_heads, head_dim])
-    k = tensor.transpose(x=k, perm=[0, 2, 1, 3])
-    attention = layers.matmul(x=q, y=k, transpose_y=True, alpha=head_dim**-0.5)
+    q = paddle.tensor.reshape(x=query_feature[0], shape=[0, 0, num_heads, head_dim])
+    q = paddle.tensor.transpose(x=q, perm=[0, 2, 1, 3])
+    k = paddle.tensor.reshape(x=key_feature[0], shape=[0, 0, num_heads, head_dim])
+    k = paddle.tensor.transpose(x=k, perm=[0, 2, 1, 3])
+    attention = paddle.matmul(x=q, y=k, transpose_y=True)
 
     attention = attention.sum(1)
     mask_sum_attention = (attention * masked_positions.unsqueeze(2)).sum(axis=1)
@@ -212,9 +210,9 @@ def attention_predict_fn_on_paddlenlp_pretrain(inputs,
     probas = paddle.nn.functional.softmax(logits, axis=2)  # get probabilities.
     preds = paddle.argmax(probas, axis=2)  # get predictions.
     mask_num = mask_num.squeeze().tolist()
-    probas = paddle.gather_nd(probas, layers.where(masked_positions))
+    probas = paddle.gather_nd(probas, paddle.fluid.layers.where(masked_positions))
     probas = probas.split(num_or_sections=mask_num)
-    preds = paddle.gather_nd(preds, layers.where(masked_positions))
+    preds = paddle.gather_nd(preds, paddle.fluid.layers.where(masked_positions))
     preds = preds.split(num_or_sections=mask_num)
 
     return attention.numpy(), preds, probas
@@ -233,9 +231,9 @@ def general_predict_fn_on_paddlenlp_pretrain(inputs, paddle_model):
     probas = paddle.nn.functional.softmax(logits, axis=2)  # get probabilities.
     preds = paddle.argmax(probas, axis=2)  # get predictions.
     mask_num = mask_num.squeeze().tolist()
-    probas = paddle.gather_nd(probas, layers.where(masked_positions))
+    probas = paddle.gather_nd(probas, paddle.fluid.layers.where(masked_positions))
     probas = probas.split(num_or_sections=mask_num)
-    preds = paddle.gather_nd(preds, layers.where(masked_positions))
+    preds = paddle.gather_nd(preds, paddle.fluid.layers.where(masked_positions))
     preds = preds.split(num_or_sections=mask_num)
 
     return preds, probas


### PR DESCRIPTION
TrustAI hasn't been updated for a long time, and it's no longer compatible with paddle 2.5 and above that discard the paddle.fluid API. With this in mind, I used the official paddle migration tool to update paddle.fluid to a new version of the code that paddle can support.